### PR TITLE
Issue 36 possible solution

### DIFF
--- a/jquery.sb.js
+++ b/jquery.sb.js
@@ -206,8 +206,12 @@
         
         loadSB = function() {
             
+            // generate new sb ID and assign it to the original select
+            var id = 'sb' + randInt();
+            $orig.attr( 'sbid', id );
+        	
             // create the new sb
-            $sb = $("<div class='sb " + o.selectboxClass + " " + $orig.attr("class") + "' id='sb" + randInt() + "'></div>")
+            $sb = $("<div class='sb " + o.selectboxClass + " " + $orig.attr("class") + "' id='" + id + "'></div>")
                 .attr("role", "listbox")
                 .attr("aria-has-popup", "true")
                 .attr("aria-labelledby", $label.attr("id") ? $label.attr("id") : "");


### PR DESCRIPTION
SelectBox creation adds a 'sbid' attribute to the original select containing the ID of the newly created SelectBox. This allows code acting on the original selects to be changed to also act on the generated SelectBoxes (hiding and showing them for example).

This aims to solve the following issue: https://github.com/revsystems/jQuery-SelectBox/issues/36
